### PR TITLE
feat(dc): Enhance functionality and add error handling

### DIFF
--- a/dc/main.py
+++ b/dc/main.py
@@ -1,10 +1,45 @@
 from telethon.tl.functions.users import GetFullUserRequest
-from telethon.tl.types import MessageEntityMentionName, MessageEntityPhone, ChatPhotoEmpty
+from telethon.tl.types import MessageEntityMentionName, ChatPhotoEmpty, User, Chat, Channel
 from struct import error as StructError
+from telethon.utils import get_peer_id
 
 from pagermaid.config import Config
 from pagermaid.utils import lang
 from pagermaid.listener import listener
+
+DC_LOCATIONS = {
+    1: "美国 迈阿密",
+    2: "荷兰 阿姆斯特丹",
+    3: "美国 迈阿密",
+    4: "荷兰 阿姆斯特丹",
+    5: "新加坡",
+}
+
+
+def _format_dc_info(entity):
+    """Formats the DC information string from a user or chat entity."""
+    if not entity.photo or isinstance(entity.photo, ChatPhotoEmpty):
+        if isinstance(entity, User):
+            return "[dc] 目标用户没有头像或头像对我不可见。"
+        if isinstance(entity, Channel):
+            return "[dc] 当前频道没有头像。" if entity.broadcast else "[dc] 当前群组没有头像。"
+        if isinstance(entity, Chat):
+            return "[dc] 当前群组没有头像。"
+        # Fallback
+        return "[dc] 当前对话没有头像或头像对我不可见。"
+
+    dc_id = entity.photo.dc_id
+    location = DC_LOCATIONS.get(dc_id, "未知")
+
+    name = ""
+    if isinstance(entity, User):
+        name = entity.first_name
+        if entity.last_name:
+            name = f"{name} {entity.last_name}"
+    else:  # Chat or Channel
+        name = entity.title
+
+    return f"**{name}** 所在数据中心为: **DC{dc_id} ({location})**"
 
 
 @listener(
@@ -14,82 +49,67 @@ from pagermaid.listener import listener
 )
 async def dc(context):
     if len(context.parameter) > 1:
-        await context.edit(f"{lang('error_prefix')}{lang('arg_error')}")
-        return
+        return await context.edit(f"{lang('error_prefix')}{lang('arg_error')}")
+
     if not Config.SILENT:
         await context.edit(lang('profile_process'))
-    if context.reply_to_msg_id:
-        reply_message = await context.get_reply_message()
-        if not reply_message:
+
+    try:
+        entity = None
+        if context.reply_to_msg_id:
+            reply_message = await context.get_reply_message()
+            if not reply_message:
+                return await context.edit(f"{lang('error_prefix')}{lang('arg_error')}")
+
+            user_id = None
+            if reply_message.fwd_from:
+                if reply_message.fwd_from.from_id:
+                    user_id = get_peer_id(reply_message.fwd_from.from_id)
+                else:
+                    return await context.edit("[dc] 无法获取匿名转发来源的 DC 信息。")
+            else:
+                user_id = reply_message.sender_id
+
+            if not user_id:
+                return await context.edit("[dc] 无法获取到回复消息的发送者。")
+
+            entity = await context.client.get_entity(user_id)
+
+        elif context.parameter:
+            user_input = context.parameter[0]
+            # Try to get entity from mention first
+            if context.message.entities:
+                for msg_entity in context.message.entities:
+                    if isinstance(msg_entity, MessageEntityMentionName):
+                        entity = await context.client.get_entity(msg_entity.user_id)
+                        break
+            if not entity:
+                entity = await context.client.get_entity(user_input)
+        else:
+            entity = await context.get_chat()
+
+        if not entity:
             return await context.edit(f"{lang('error_prefix')}{lang('arg_error')}")
-        
-        user_id = reply_message.from_id
-        if not user_id:
-             # Should not happen, but as a safeguard
-             return await context.edit("[dc] 无法获取到回复消息的发送者。")
 
-        try:
-            # First, assume it's a user
-            target_user = await context.client(GetFullUserRequest(user_id))
-            user_info = target_user.users[0]
-            if isinstance(user_info.photo, ChatPhotoEmpty):
-                return await context.edit("[dc] 目标用户没有头像。")
-            await context.edit(f"**{user_info.first_name}** 所在数据中心为: **DC{user_info.photo.dc_id}**")
-            return
-        except (TypeError, ValueError):
-            # If GetFullUserRequest fails, it might be a channel
-            try:
-                chat = await reply_message.get_chat()
-                if not chat or not hasattr(chat, 'photo') or isinstance(chat.photo, ChatPhotoEmpty):
-                    return await context.edit("[dc] 回复的消息所在对话需要先设置头像并且对我可见。")
-                await context.edit(f"**{chat.title}** 所在数据中心为: **DC{chat.photo.dc_id}**")
-                return
-            except Exception:
-                 return await context.edit("[dc] 无法获取该对象的 DC 信息。")
-    else:
-        if len(context.parameter) == 0:
-            chat = await context.get_chat()
-            if isinstance(chat.photo, ChatPhotoEmpty):
-                return await context.edit("[dc] 当前群组/频道没有头像。")
-            await context.edit(f"**{chat.title}** 所在数据中心为: **DC{chat.photo.dc_id}**")
-            return
+        # For users, we need GetFullUserRequest to get the photo dc_id reliably
+        if isinstance(entity, User):
+            full_user = await context.client(GetFullUserRequest(entity.id))
+            entity = full_user.users[0]
 
-        user = None
-        if context.message.entities:
-            for entity in context.message.entities:
-                if isinstance(entity, MessageEntityMentionName):
-                    user = entity.user_id
-                    break
-                if isinstance(entity, MessageEntityPhone):
-                    user = int(context.parameter[0])
-                    break
-        
-        if not user:
-            user = context.parameter[0]
-            if user.isnumeric():
-                user = int(user)
+        message = _format_dc_info(entity)
+        await context.edit(message)
 
-        if not user:
-            await context.edit(f"{lang('error_prefix')}{lang('arg_error')}")
-            return
-        try:
-            user_object = await context.client.get_entity(user)
-            target_user = await context.client(GetFullUserRequest(user_object.id))
-            user_info = target_user.users[0]
-            if not user_info.photo:
-                return await context.edit("[dc] 目标用户需要先设置头像并且对我可见。")
-            await context.edit(f"**{user_info.first_name}** 所在数据中心为: **DC{user_info.photo.dc_id}**")
-        except (TypeError, ValueError, OverflowError, StructError) as exception:
-            if str(exception).startswith("Cannot find any entity corresponding to"):
-                await context.edit(f"{lang('error_prefix')}{lang('profile_e_no')}")
-                return
-            if str(exception).startswith("No user has"):
-                await context.edit(f"{lang('error_prefix')}{lang('profile_e_nou')}")
-                return
-            if str(exception).startswith("Could not find the input entity for") or isinstance(exception, StructError):
-                await context.edit(f"{lang('error_prefix')}{lang('profile_e_nof')}")
-                return
-            if isinstance(exception, OverflowError):
-                await context.edit(f"{lang('error_prefix')}{lang('profile_e_long')}")
-                return
-            raise exception
+    except Exception as e:
+        error_str = str(e)
+        if "Cannot find any entity corresponding to" in error_str:
+            await context.edit(f"{lang('error_prefix')}{lang('profile_e_no')}")
+        elif "No user has" in error_str:
+            await context.edit(f"{lang('error_prefix')}{lang('profile_e_nou')}")
+        elif "Could not find the input entity for" in error_str or isinstance(e, StructError):
+            await context.edit(f"{lang('error_prefix')}{lang('profile_e_nof')}")
+        elif isinstance(e, OverflowError):
+            await context.edit(f"{lang('error_prefix')}{lang('profile_e_long')}")
+        elif isinstance(e, IndexError):  # From full_user.users[0]
+            await context.edit("[dc] 无法获取该用户的完整信息。")
+        else:
+            await context.edit(f"{lang('error_prefix')}获取 DC 信息时出现未知错误: {e}")

--- a/list.json
+++ b/list.json
@@ -122,10 +122,10 @@
         },
         {
             "name": "dc",
-            "version": "1.03",
+            "version": "1.04",
             "section": "chat",
-            "maintainer": "xiluo",
-            "size": "4.37 kb",
+            "maintainer": "xiluo、outlook84",
+            "size": "5.87 kb",
             "supported": true,
             "des_short": "获取指定用户或当前群组/频道的 DC 服务器",
             "des": "获取指定用户或当前群组/频道的 DC 服务器(指令: ,dc)"


### PR DESCRIPTION
This commit introduces several improvements and bug fixes to the `dc` plugin.

- Displays the geographical location for each Data Center (DC) ID.
- Adds support for retrieving the DC information of the original sender when replying to a forwarded message.
- Fixes an issue where the sender's ID could not be retrieved when using the command as a reply in private messages.
- Resolves a crash that occurred when the target user has no profile picture set.

## 该 PR 相关 Issue / Involved issue

Close #

## 插件名称 / Name

```
dc
```

## 更改检查表 / Change Checklist
  
- [x] 有插件版本号更新
- [ ] 有多语言支持
  - [ ] CN
  - [ ] EN
- [ ] 会触发频率限制 Will trigger a rate limit?
  - [ ] 如果会, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] 添加了新的依赖包 New package added

## 说明 / Note
