### PR TITLE
fix(gemini & ytdl): Adjust TTS limit and fix ytdl plugin

### DIFF
--- a/gemini/main.py
+++ b/gemini/main.py
@@ -356,7 +356,7 @@ async def _call_gemini_tts_api(message: Message, text: str) -> tuple[str | None,
 
         model_name = db.get(Config.TTS_MODEL, Config.DEFAULT_TTS_MODEL)
         token_count_response = client.models.count_tokens(model=f"models/{model_name}", contents=[clean_text])
-        if token_count_response.total_tokens > 1500:
+        if token_count_response.total_tokens > 1000:
             raise ValueError(f"TOKEN_LIMIT_EXCEEDED:{token_count_response.total_tokens}")
 
         voice_name = db.get(Config.TTS_VOICE, Config.DEFAULT_TTS_VOICE)

--- a/gemini/main.py
+++ b/gemini/main.py
@@ -983,7 +983,7 @@ async def _handle_tts(message: Message, args: str):
     except ValueError as e:
         if str(e).startswith("TOKEN_LIMIT_EXCEEDED"):
             total_tokens = str(e).split(":")[1].strip()
-            await _show_error(message, f"文本超过 1500 tokens 限制 ({total_tokens} tokens)，无法生成语音。")
+            await _show_error(message, f"文本超过 1000 tokens 限制 ({total_tokens} tokens)，无法生成语音。")
         else:
             await _show_error(message, f"发生意外错误: {e}")
 
@@ -1017,7 +1017,7 @@ async def _execute_audio_request(message: Message, args: str, use_search: bool):
     except ValueError as e:
         if str(e).startswith("TOKEN_LIMIT_EXCEEDED"):
             total_tokens = str(e).split(":")[1].strip()
-            fallback_reason = f"文本超过 1500 tokens 限制 ({total_tokens} tokens)。"
+            fallback_reason = f"文本超过 1000 tokens 限制 ({total_tokens} tokens)。"
             tts_result = False
         else:
             raise e

--- a/list.json
+++ b/list.json
@@ -192,7 +192,7 @@
         },
         {
             "name": "gemini",
-            "version": "0.9",
+            "version": "0.91",
             "section": "chat",
             "maintainer": "outlook84",
             "size": "47.4 kb",
@@ -332,7 +332,7 @@
         },
         {
             "name": "ytdl",
-            "version": "2.3",
+            "version": "2.31",
             "section": "chat",
             "maintainer": "xtaodada",
             "size": "12.0 kb",

--- a/ytdl/main.py
+++ b/ytdl/main.py
@@ -9,7 +9,7 @@ import httpx
 import importlib
 
 from telethon import types
-from telethon.tl.types import DocumentAttributeAudio
+from telethon.tl.types import DocumentAttributeAudio, DocumentAttributeVideo
 
 from pagermaid.enums import Message, AsyncClient
 from pagermaid.listener import listener
@@ -17,7 +17,7 @@ from pagermaid.services import bot, sqlite as db
 from pagermaid.utils import pip_install
 
 dependencies = {
-    "yt_dlp": "yt-dlp[default,curl-cffi]",
+    "yt_dlp": "yt-dlp[curl-cffi]",
     "FastTelethonhelper": "FastTelethonhelper",
 }
 
@@ -192,7 +192,7 @@ async def ytdl_common(message: Message, file_type: str, proxy: str = None):
         if duration:
             if file_type == "video":
                 attributes.append(
-                    types.DocumentAttributeVideo(
+                    DocumentAttributeVideo(
                         duration=duration, w=width or 0, h=height or 0
                     )
                 )
@@ -351,4 +351,4 @@ async def ytdl_update(message: Message, client: AsyncClient):
         await message.edit("获取最新版本信息失败，请稍后再试。")
         return
     pip_install("yt-dlp[default,curl-cffi]", version=f">={latest_version}", alias="a")
-    await message.edit(f"yt-dlp 已更新到最新版本：{latest_version}。")
+    await message.edit(f"yt-dlp 已更新到最新版本：{latest_version}。重启 PagerMaid 后生效。")

--- a/ytdl/main.py
+++ b/ytdl/main.py
@@ -350,5 +350,5 @@ async def ytdl_update(message: Message, client: AsyncClient):
     except Exception:
         await message.edit("获取最新版本信息失败，请稍后再试。")
         return
-    pip_install("yt-dlp[default,curl-cffi]", version=f">={latest_version}", alias="a")
+    pip_install("yt-dlp[curl-cffi]", version=f">={latest_version}", alias="a")
     await message.edit(f"yt-dlp 已更新到最新版本：{latest_version}。重启 PagerMaid 后生效。")


### PR DESCRIPTION
This commit introduces two changes:

In the Gemini module, the token limit for Text-to-Speech (TTS) is reduced from 1500 to 1000. This prevents API errors when processing longer text inputs that exceed the model's actual capacity.

In the ytdl module:
- The `[default]` extra is removed from the `yt-dlp` dependency since it breaks latest yt-dlp version in this script. I don't know why it break the script, yt-dlp works fine in test script outside of pagermaid. Any way, `default` extra hasn't been used in code.
- The update confirmation message is improved to clarify that a restart is required for the new version to take effect.

## 该 PR 相关 Issue / Involved issue

Close #

## 插件名称 / Name

```
gemini
ytdl
```

## 更改检查表 / Change Checklist
  
- [x] 有插件版本号更新
- [ ] 有多语言支持
  - [ ] CN
  - [ ] EN
- [ ] 会触发频率限制 Will trigger a rate limit?
  - [ ] 如果会, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] 添加了新的依赖包 New package added

## 说明 / Note

## Summary by Sourcery

Adjust TTS token limit in the Gemini module and fix compatibility issues in the ytdl plugin, including dependency adjustments and an improved update message.

Bug Fixes:
- Reduce TTS token limit from 1500 to 1000 to prevent API errors on long inputs
- Remove the `[default]` extra from the `yt-dlp` dependency to restore compatibility with the latest yt-dlp version

Enhancements:
- Clarify in the ytdl update confirmation message that a restart is required for the new version to take effect